### PR TITLE
Ported tweaks from svelte-rating to thought_tagger

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,10 +28,13 @@
         }
       }
       if (!params.workerId && !params.assignmentId && !params.hitId) {
-        var div = document.createElement('div');
-        var content = document.createTextNode('Not authorized');
-        div.appendChild(content);
-        document.body.appendChild(div);
+        // var div = document.createElement('div');
+        // var content = document.createTextNode('Not authorized');
+        // div.appendChild(content);
+        // document.body.appendChild(div);
+        var app = document.createElement('script');
+        app.setAttribute('src', 'bundle.js');
+        document.body.appendChild(app);
         console.log('Non mturk referal');
       } else if (params.assignmentId === 'ASSIGNMENT_ID_NOT_AVAILABLE') {
         // TODO: Move this logic to App.svelte

--- a/public/index.html
+++ b/public/index.html
@@ -28,13 +28,10 @@
         }
       }
       if (!params.workerId && !params.assignmentId && !params.hitId) {
-        // var div = document.createElement('div');
-        // var content = document.createTextNode('Not authorized');
-        // div.appendChild(content);
-        // document.body.appendChild(div);
-        var app = document.createElement('script');
-        app.setAttribute('src', 'bundle.js');
-        document.body.appendChild(app);
+        var div = document.createElement('div');
+        var content = document.createTextNode('Not authorized');
+        div.appendChild(content);
+        document.body.appendChild(div);
         console.log('Non mturk referal');
       } else if (params.assignmentId === 'ASSIGNMENT_ID_NOT_AVAILABLE') {
         // TODO: Move this logic to App.svelte

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -99,7 +99,7 @@
 <section class="section">
   {#if !currentState}
     <Loading>Loading...</Loading>
-  {:else if currentState === 'instructions'}
+  {:else if currentState === 'instructions' || currentState === 'completed'}
     <Instructions on:finished={() => updateState('quiz')} />
   {:else if currentState === 'quiz'}
     <Quiz

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -39,7 +39,7 @@
           try {
             await auth.signInWithEmailAndPassword(
               `${params.workerId}@experiment.com`,
-              params.assignmentId
+              params.workerId
             );
             console.log('user found...signing in with credentials');
           } catch (error) {
@@ -47,7 +47,7 @@
               console.log('no user found...creating new credentials');
               await auth.createUserWithEmailAndPassword(
                 `${params.workerId}@experiment.com`,
-                params.assignmentId
+                params.workerId
               );
             } else {
               console.error(error);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -78,11 +78,11 @@
                 assignmentId: params.assignmentId,
                 hitId: params.hitId,
                 startTime: serverTime,
-                currentState: 'instructions',
+                currentState: 'consent',
                 currentTrial: 1,
                 trialOrder
               });
-              currentState = 'instructions';
+              currentState = 'consent';
               console.log('no previous document found...creating new...');
             }
           } catch (error) {
@@ -99,7 +99,9 @@
 <section class="section">
   {#if !currentState}
     <Loading>Loading...</Loading>
-  {:else if currentState === 'instructions' || currentState === 'completed'}
+  {:else if currentState === 'consent' || currentState === 'completed'}
+    <Consent on:finished={() => updateState('instructions')} />
+  {:else if currentState === 'instructions'}
     <Instructions on:finished={() => updateState('quiz')} />
   {:else if currentState === 'quiz'}
     <Quiz

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,6 +4,7 @@
   import { db, auth, fisherYatesShuffle, serverTime, params } from './utils.js';
   import Instructions from './pages/Instructions.svelte';
   import Quiz from './pages/Quiz.svelte';
+  import Consent from './pages/Consent.svelte';
   import Experiment from './pages/Experiment.svelte';
   import Debrief from './pages/Debrief.svelte';
   import Loading from './components/Loading.svelte';

--- a/src/pages/Consent.svelte
+++ b/src/pages/Consent.svelte
@@ -1,62 +1,18 @@
 <script>
-  // This is the Instructions page. It loops over the instructions array as a user reads and when click to the last page it notifies the main App.svelte component by dispatching a 'finished' event. When the last page of the instructions are reached the forward button turns into a "Take Quiz" button, but currently there is no quiz and it goes straight to the experiment
   import { createEventDispatcher } from 'svelte';
 
   // Add/remove items here to create more instructions pages
   const consent = [
-    'Please read the following material that explains this research study. We want you to understand what you are being asked to do and what risks and benefits if any are associated with the study. Consent with this form will indicate that you have been informed about the study and that you want to participate.',
+    'We need your consent to proceed. The following material explains this research study. We want you to understand what you are being asked to do and what risks and benefits, if any, are associated with the study. Consent with this form will indicate that you have been informed about the study and that you want to participate.',
 
-    'This project is being conducted by researchers from the department of Psychological and Brain Sciences at Dartmouth College, Hanover, NH, USA. This study aims to understand how individuals experience different feelings in response to narratives.',
+    'This project is being conducted by researchers from the department of Psychological and Brain Sciences at Dartmouth College, Hanover, NH, USA. This study aims to understand INSERT AIM OF STUDY HERE.',
 
-    'Your participation is voluntary. Participation involves periodically making behavioral judgments about how you are feeling in response to video/audio clips, pictures, and text excerpts. The clips will be from public radio, primetime television, or YouTube..'
+    'Your participation is voluntary. Participation involves INSERT BASIC SUMMARY OF PARTICIPATION INVOLVEMENT HERE',
+
+    'If you decide to take part in this study, you will be asked to listen to a variety of media that vary in emotional content. If any of the media presented should make you feel too uncomfortable to continue with the study, you are free to immediately withdraw your participation without giving up payment (send us an email <a href="mailto:eshin.jolly@gmail.com">here</a> after withdrawing for payment information). To be clear: you may immediately end your participation if any aspect of the research procedure makes you too uncomfortable to continue. Lastly, if you have any discomfort or concerns after viewing the media, you are encouraged to contact the principal investigator <a href="mailto:eshin.jolly@gmail.com">here</a>',
+
+    'The information collected will be anonymous and no identifying information will be stored with the data collected during the experiment. Identifying information will not be used in any presentation or paper written about this project and such presentations will represent the aggregation of data from groups of people. <br><br> Do you understand and consent to these terms?'
   ];
-
-  // <h1>We need your consent to proceed</h1>
-  //   <p>
-  //     <strong>(Please scroll down to see all consent information.)</strong>
-  //   </p>
-  //   <div class="consent-box">
-  //     <p class="intro">
-  //       "Please read the following material that explains this research study. We want you to
-  //       understand what you are being asked to do and what risks and benefits --if any-- are
-  //       associated with the study. Consent with this form will indicate that you have been informed
-  //       about the study and that you want to participate."
-  //     </p>
-
-  //     <p>
-  //       This project is being conducted by researchers from the department of Psychological and
-  //       Brain Sciences at Dartmouth College, Hanover, NH, USA. This study aims to understand how
-  //       individuals experience different feelings in response to narratives.
-  //     </p>
-
-  //     <p>
-  //       Your participation is voluntary. Participation involves periodically making behavioral
-  //       judgments about how you are feeling in response to video/audio clips, pictures, and text
-  //       excerpts. The clips will be from public radio, primetime television, or YouTube.
-  //     </p>
-
-  //     <p>
-  //       If you decide to take part in this study, you may be asked to view a variety of media that
-  //       vary in emotional content. If any of the media presented should make you feel too
-  //       uncomfortable to continue with the study, you are free to immediately withdraw your
-  //       participation without giving up payment (send us an email
-  //       <a href="mailto:eshin.jolly@gmail.com">here</a>
-  //       after withdrawing for payment information). To be clear: you may immediately end your
-  //       participation if any aspect of the research procedure makes you too uncomfortable to
-  //       continue. Lastly, if you have any discomfort or concerns after viewing the media, you are
-  //       encouraged to contact the principal investigator
-  //       <a href="mailto:eshin.jolly@gmail.com">here</a>
-  //     </p>
-
-  //     <p>
-  //       The information collected will be anonymous and no identifying information will be stored
-  //       with the data collected during the experiment. Identifying information will not be used in
-  //       any presentation or paper written about this project and such presentations will represent
-  //       the aggregation of data from groups of people.
-  //     </p>
-  //   </div>
-
-  //   <h2>Do you understand and consent to these terms?</h2>
 
   const dispatch = createEventDispatcher();
   let currentPage = 0;

--- a/src/pages/Consent.svelte
+++ b/src/pages/Consent.svelte
@@ -1,0 +1,101 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+  let consentRejected = false;
+
+  function handleYes() {
+    dispatch('finished');
+  }
+
+  function handleNo() {
+    consentRejected = true;
+    dispatch('return');
+  }
+</script>
+
+<style>
+  .container {
+    margin: 0 auto !important;
+    align-items: center;
+    text-align: center;
+    width: 50%;
+  }
+
+  .consent-box {
+    text-align: left;
+    padding: 2%;
+    background-color: rgba(255, 255, 255, 0.4);
+    border: 2px solid grey;
+    border-radius: 2px;
+    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  .intro {
+    font-style: italic;
+  }
+
+  .yes {
+    background-color: lightblue;
+  }
+
+  .no {
+    background-color: lightcoral;
+  }
+</style>
+
+<!-- this page handles the consent -->
+<div class="container">
+  {#if consentRejected}
+    <p>Thank you for your time. You may exit the page.</p>
+  {:else}
+    <h1>We need your consent to proceed</h1>
+    <p>
+      <strong>(Please scroll down to see all consent information.)</strong>
+    </p>
+    <div class="consent-box">
+      <p class="intro">
+        Please read the following material that explains this research study. We want you to
+        understand what you are being asked to do and what risks and benefits --if any-- are
+        associated with the study. Consent with this form will indicate that you have been informed
+        about the study and that you want to participate.
+      </p>
+
+      <p>
+        This project is being conducted by researchers from the department of Psychological and
+        Brain Sciences at Dartmouth College, Hanover, NH, USA. This study aims to understand how
+        individuals experience different feelings in response to narratives.
+      </p>
+
+      <p>
+        Your participation is voluntary. Participation involves periodically making behavioral
+        judgments about how you are feeling in response to video/audio clips, pictures, and text
+        excerpts. The clips will be from public radio, primetime television, or YouTube.
+      </p>
+
+      <p>
+        If you decide to take part in this study, you may be asked to view a variety of media that
+        vary in emotional content. If any of the media presented should make you feel too
+        uncomfortable to continue with the study, you are free to immediately withdraw your
+        participation without giving up payment (send us an email
+        <a href="mailto:eshin.jolly@gmail.com">here</a>
+        after withdrawing for payment information). To be clear: you may immediately end your
+        participation if any aspect of the research procedure makes you too uncomfortable to
+        continue. Lastly, if you have any discomfort or concerns after viewing the media, you are
+        encouraged to contact the principal investigator
+        <a href="mailto:eshin.jolly@gmail.com">here</a>
+      </p>
+
+      <p>
+        The information collected will be anonymous and no identifying information will be stored
+        with the data collected during the experiment. Identifying information will not be used in
+        any presentation or paper written about this project and such presentations will represent
+        the aggregation of data from groups of people.
+      </p>
+    </div>
+
+    <h2>Do you understand and consent to these terms?</h2>
+
+    <button class="yes" on:click={handleYes}>I agree</button>
+    <button class="no" on:click={handleNo}>No thanks, I do not want to do this HIT</button>
+  {/if}
+</div>

--- a/src/pages/Consent.svelte
+++ b/src/pages/Consent.svelte
@@ -11,7 +11,7 @@
 
     'If you decide to take part in this study, you will be asked to listen to a variety of media that vary in emotional content. If any of the media presented should make you feel too uncomfortable to continue with the study, you are free to immediately withdraw your participation without giving up payment (send us an email <a href="mailto:eshin.jolly@gmail.com">here</a> after withdrawing for payment information). To be clear: you may immediately end your participation if any aspect of the research procedure makes you too uncomfortable to continue. Lastly, if you have any discomfort or concerns after viewing the media, you are encouraged to contact the principal investigator <a href="mailto:eshin.jolly@gmail.com">here</a>',
 
-    'The information collected will be anonymous and no identifying information will be stored with the data collected during the experiment. Identifying information will not be used in any presentation or paper written about this project and such presentations will represent the aggregation of data from groups of people. <br><br> Do you understand and consent to these terms?'
+    'The information collected will be anonymous and no identifying information will be stored with the data collected during the experiment. Identifying information will not be used in any presentation or paper written about this project and such presentations will represent the aggregation of data from groups of people. <br><br> <strong>Do you understand and consent to these terms?</strong> If so, press Accept, otherwise please return this HIT.'
   ];
 
   const dispatch = createEventDispatcher();

--- a/src/pages/Consent.svelte
+++ b/src/pages/Consent.svelte
@@ -1,101 +1,128 @@
 <script>
+  // This is the Instructions page. It loops over the instructions array as a user reads and when click to the last page it notifies the main App.svelte component by dispatching a 'finished' event. When the last page of the instructions are reached the forward button turns into a "Take Quiz" button, but currently there is no quiz and it goes straight to the experiment
   import { createEventDispatcher } from 'svelte';
+
+  // Add/remove items here to create more instructions pages
+  const consent = [
+    'Please read the following material that explains this research study. We want you to understand what you are being asked to do and what risks and benefits if any are associated with the study. Consent with this form will indicate that you have been informed about the study and that you want to participate.',
+
+    'This project is being conducted by researchers from the department of Psychological and Brain Sciences at Dartmouth College, Hanover, NH, USA. This study aims to understand how individuals experience different feelings in response to narratives.',
+
+    'Your participation is voluntary. Participation involves periodically making behavioral judgments about how you are feeling in response to video/audio clips, pictures, and text excerpts. The clips will be from public radio, primetime television, or YouTube..'
+  ];
+
+  // <h1>We need your consent to proceed</h1>
+  //   <p>
+  //     <strong>(Please scroll down to see all consent information.)</strong>
+  //   </p>
+  //   <div class="consent-box">
+  //     <p class="intro">
+  //       "Please read the following material that explains this research study. We want you to
+  //       understand what you are being asked to do and what risks and benefits --if any-- are
+  //       associated with the study. Consent with this form will indicate that you have been informed
+  //       about the study and that you want to participate."
+  //     </p>
+
+  //     <p>
+  //       This project is being conducted by researchers from the department of Psychological and
+  //       Brain Sciences at Dartmouth College, Hanover, NH, USA. This study aims to understand how
+  //       individuals experience different feelings in response to narratives.
+  //     </p>
+
+  //     <p>
+  //       Your participation is voluntary. Participation involves periodically making behavioral
+  //       judgments about how you are feeling in response to video/audio clips, pictures, and text
+  //       excerpts. The clips will be from public radio, primetime television, or YouTube.
+  //     </p>
+
+  //     <p>
+  //       If you decide to take part in this study, you may be asked to view a variety of media that
+  //       vary in emotional content. If any of the media presented should make you feel too
+  //       uncomfortable to continue with the study, you are free to immediately withdraw your
+  //       participation without giving up payment (send us an email
+  //       <a href="mailto:eshin.jolly@gmail.com">here</a>
+  //       after withdrawing for payment information). To be clear: you may immediately end your
+  //       participation if any aspect of the research procedure makes you too uncomfortable to
+  //       continue. Lastly, if you have any discomfort or concerns after viewing the media, you are
+  //       encouraged to contact the principal investigator
+  //       <a href="mailto:eshin.jolly@gmail.com">here</a>
+  //     </p>
+
+  //     <p>
+  //       The information collected will be anonymous and no identifying information will be stored
+  //       with the data collected during the experiment. Identifying information will not be used in
+  //       any presentation or paper written about this project and such presentations will represent
+  //       the aggregation of data from groups of people.
+  //     </p>
+  //   </div>
+
+  //   <h2>Do you understand and consent to these terms?</h2>
+
   const dispatch = createEventDispatcher();
-  let consentRejected = false;
+  let currentPage = 0;
 
-  function handleYes() {
-    dispatch('finished');
-  }
-
-  function handleNo() {
-    consentRejected = true;
-    dispatch('return');
-  }
+  const backward = () => {
+    currentPage -= 1;
+    currentPage = Math.max(currentPage, 0);
+  };
+  const forward = () => {
+    // Check if we're increasing the value of currentPage beyond the number of instructions, if so tell App.svelte we're ready to move to the quiz
+    if (currentPage + 1 === consent.length) {
+      dispatch('finished');
+    } else {
+      currentPage += 1;
+      currentPage = Math.min(currentPage, consent.length - 1);
+    }
+  };
 </script>
 
 <style>
-  .container {
-    margin: 0 auto !important;
-    align-items: center;
-    text-align: center;
-    width: 50%;
+  .no-space-hr {
+    margin: 0;
   }
-
-  .consent-box {
-    text-align: left;
-    padding: 2%;
-    background-color: rgba(255, 255, 255, 0.4);
-    border: 2px solid grey;
-    border-radius: 2px;
-    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1);
+  .custom-card-title {
+    margin-bottom: 2% !important;
+    padding-top: 2% !important;
   }
-
-  .intro {
-    font-style: italic;
-  }
-
-  .yes {
-    background-color: lightblue;
-  }
-
-  .no {
-    background-color: lightcoral;
+  .controls {
+    min-width: 50%;
   }
 </style>
 
-<!-- this page handles the consent -->
 <div class="container">
-  {#if consentRejected}
-    <p>Thank you for your time. You may exit the page.</p>
-  {:else}
-    <h1>We need your consent to proceed</h1>
-    <p>
-      <strong>(Please scroll down to see all consent information.)</strong>
-    </p>
-    <div class="consent-box">
-      <p class="intro">
-        Please read the following material that explains this research study. We want you to
-        understand what you are being asked to do and what risks and benefits --if any-- are
-        associated with the study. Consent with this form will indicate that you have been informed
-        about the study and that you want to participate.
-      </p>
-
-      <p>
-        This project is being conducted by researchers from the department of Psychological and
-        Brain Sciences at Dartmouth College, Hanover, NH, USA. This study aims to understand how
-        individuals experience different feelings in response to narratives.
-      </p>
-
-      <p>
-        Your participation is voluntary. Participation involves periodically making behavioral
-        judgments about how you are feeling in response to video/audio clips, pictures, and text
-        excerpts. The clips will be from public radio, primetime television, or YouTube.
-      </p>
-
-      <p>
-        If you decide to take part in this study, you may be asked to view a variety of media that
-        vary in emotional content. If any of the media presented should make you feel too
-        uncomfortable to continue with the study, you are free to immediately withdraw your
-        participation without giving up payment (send us an email
-        <a href="mailto:eshin.jolly@gmail.com">here</a>
-        after withdrawing for payment information). To be clear: you may immediately end your
-        participation if any aspect of the research procedure makes you too uncomfortable to
-        continue. Lastly, if you have any discomfort or concerns after viewing the media, you are
-        encouraged to contact the principal investigator
-        <a href="mailto:eshin.jolly@gmail.com">here</a>
-      </p>
-
-      <p>
-        The information collected will be anonymous and no identifying information will be stored
-        with the data collected during the experiment. Identifying information will not be used in
-        any presentation or paper written about this project and such presentations will represent
-        the aggregation of data from groups of people.
-      </p>
+  <div class="columns is-centered">
+    <div class="column is-three-fifths ">
+      <div class="card">
+        <div class="has-text-centered">
+          <h1 class="title is-2 custom-card-title">Consent</h1>
+          <hr class="no-space-hr" />
+        </div>
+        <div class="card-content">
+          <div class="content">
+            {@html consent[currentPage]}
+          </div>
+        </div>
+        <footer class="card-footer">
+          <p class="card-footer-item">
+            <button class="button is-link controls" on:click={backward}>
+              <span class="icon">
+                <i class="fas fa-backward" />
+              </span>
+            </button>
+          </p>
+          <p class="card-footer-item">
+            <button class="button is-link controls" on:click={forward}>
+              {#if currentPage === consent.length - 1}
+                Accept consent
+              {:else}
+                <span class="icon">
+                  <i class="fas fa-forward" />
+                </span>
+              {/if}
+            </button>
+          </p>
+        </footer>
+      </div>
     </div>
-
-    <h2>Do you understand and consent to these terms?</h2>
-
-    <button class="yes" on:click={handleYes}>I agree</button>
-    <button class="no" on:click={handleNo}>No thanks, I do not want to do this HIT</button>
-  {/if}
+  </div>
 </div>

--- a/src/pages/Debrief.svelte
+++ b/src/pages/Debrief.svelte
@@ -63,6 +63,7 @@
         <em>All questions are optional</em>
       </p>
       <form name="mturk" action={submitURL} method="POST">
+        <input type="hidden" name="assignmentId" value={params.assignmentId} />
         <div class="field is-horizontal">
           <div class="field-label is-normal">
             <label class="label">Age</label>

--- a/src/pages/Debrief.svelte
+++ b/src/pages/Debrief.svelte
@@ -3,7 +3,6 @@
   import { db, params, serverTime } from '../utils.js';
 
   let submitURL = params.turkSubmitTo + '/mturk/externalSubmit';
-  console.log('attempt:', submitURL);
   let age = '';
   let feedback = '';
   let sex = '';
@@ -65,7 +64,7 @@
       </p>
       <form name="mturk" action={submitURL} method="POST">
         <input type="hidden" name="assignmentId" id="assignmentId" value={params.assignmentId} />
-        <input type="hidden" name="foo" value="1" />
+        <input type="hidden" name="dummy_input_DONT_REMOVE" value="1" />
         <div class="field is-horizontal">
           <div class="field-label is-normal">
             <label class="label">Age</label>

--- a/src/pages/Debrief.svelte
+++ b/src/pages/Debrief.svelte
@@ -1,5 +1,5 @@
 <script>
-  // This is the debrief page in which we should collect any post survey questions. There's a single button that should save reponses to firebase and then tell PsiTurk we're done.
+  // This is the debrief page in which we should collect any post survey questions. There's a single button that should save reponses to firebase and then tell Mturk we're done.
   import { db, params, serverTime } from '../utils.js';
 
   let age = '';
@@ -33,7 +33,7 @@
       });
       console.log('exit survey added successfully');
       window.top.postMessage('finished', '*');
-      console.log('back to PsiTurk!');
+      console.log('back to MTurk!');
     } catch (error) {
       console.error(error);
     }
@@ -60,7 +60,7 @@
       <p class="subtitle is-6 has-text-centered">
         <em>All questions are optional</em>
       </p>
-      <form on:submit|preventDefault={submitHIT}>
+      <form name="mturk" action="https://www.mturk.com/mturk/externalSubmit" method="POST">
         <div class="field is-horizontal">
           <div class="field-label is-normal">
             <label class="label">Age</label>
@@ -203,7 +203,7 @@
           <div class="field-body">
             <div class="field">
               <div class="control">
-                <button class="button is-success is-large">Submit HIT</button>
+                <button class="button is-success is-large" on:click={submitHIT}>Submit HIT</button>
               </div>
             </div>
           </div>

--- a/src/pages/Debrief.svelte
+++ b/src/pages/Debrief.svelte
@@ -63,7 +63,8 @@
         <em>All questions are optional</em>
       </p>
       <form name="mturk" action={submitURL} method="POST">
-        <input type="hidden" name="assignmentId" value={params.assignmentId} />
+        <input type="hidden" name="assignmentId" id="assignmentId" value={params.assignmentId} />
+        <input type="hidden" name="foo" value="1" />
         <div class="field is-horizontal">
           <div class="field-label is-normal">
             <label class="label">Age</label>

--- a/src/pages/Debrief.svelte
+++ b/src/pages/Debrief.svelte
@@ -29,7 +29,8 @@
         birth,
         handed,
         feedback,
-        HIT_complete: serverTime
+        HIT_complete: serverTime,
+        currentState: 'completed'
       });
       console.log('exit survey added successfully');
       window.top.postMessage('finished', '*');

--- a/src/pages/Debrief.svelte
+++ b/src/pages/Debrief.svelte
@@ -3,6 +3,7 @@
   import { db, params, serverTime } from '../utils.js';
 
   let submitURL = params.turkSubmitTo + '/mturk/externalSubmit';
+  console.log('attempt:', submitURL);
   let age = '';
   let feedback = '';
   let sex = '';

--- a/src/pages/Debrief.svelte
+++ b/src/pages/Debrief.svelte
@@ -2,6 +2,7 @@
   // This is the debrief page in which we should collect any post survey questions. There's a single button that should save reponses to firebase and then tell Mturk we're done.
   import { db, params, serverTime } from '../utils.js';
 
+  let submitURL = params.turkSubmitTo + '/mturk/externalSubmit';
   let age = '';
   let feedback = '';
   let sex = '';
@@ -61,7 +62,7 @@
       <p class="subtitle is-6 has-text-centered">
         <em>All questions are optional</em>
       </p>
-      <form name="mturk" action="https://www.mturk.com/mturk/externalSubmit" method="POST">
+      <form name="mturk" action={submitURL} method="POST">
         <div class="field is-horizontal">
           <div class="field-label is-normal">
             <label class="label">Age</label>

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,6 +44,7 @@ export const getURLParams = () => {
     params.assignmentId = 'test-assignment';
     params.hitId = 'test-hit';
   }
+  console.log(params);
   return params;
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,13 +35,13 @@ export const getURLParams = () => {
       i += 1;
     }
   }
-  if (!params.workerId && !params.assignmentId && !params.hitId) {
-    console.log('Referring URL is NOT psiTurk....creating fake workerId');
-    console.log('MAKE SURE TO REMOVE THIS IN CODE BEFORE GOING LIVE');
-    params.workerId = 'test-worker';
-    params.assignmentId = 'test-assignment';
-    params.hitId = 'test-hit';
-  }
+  // if (!params.workerId && !params.assignmentId && !params.hitId) {
+  //   console.log('Referring URL is NOT psiTurk....creating fake workerId');
+  //   console.log('MAKE SURE TO REMOVE THIS IN CODE BEFORE GOING LIVE');
+  //   params.workerId = 'test-worker';
+  //   params.assignmentId = 'test-assignment';
+  //   params.hitId = 'test-hit';
+  // }
   console.log(params);
   return params;
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,7 +25,7 @@ export const serverTime = firebase.database.ServerValue.TIMESTAMP;
 // Functions to parse the URL to get workerID, hitID, and assignmentID
 const unescapeURL = (s) => decodeURIComponent(s.replace(/\+/g, '%20'));
 export const getURLParams = () => {
-  const url = window.location.hostname;
+  const url = window.location.href;
   console.log('curr host:', url);
   const params = {};
   const m = window.location.href.match(/[\\?&]([^=]+)=([^&#]*)/g);

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,13 +35,13 @@ export const getURLParams = () => {
       i += 1;
     }
   }
-  // if (!params.workerId && !params.assignmentId && !params.hitId) {
-  //   console.log('Referring URL is NOT psiTurk....creating fake workerId');
-  //   console.log('MAKE SURE TO REMOVE THIS IN CODE BEFORE GOING LIVE');
-  //   params.workerId = 'test-worker';
-  //   params.assignmentId = 'test-assignment';
-  //   params.hitId = 'test-hit';
-  // }
+  if (!params.workerId && !params.assignmentId && !params.hitId) {
+    console.log('Referring URL is NOT psiTurk....creating fake workerId');
+    console.log('MAKE SURE TO REMOVE THIS IN CODE BEFORE GOING LIVE');
+    params.workerId = 'test-worker';
+    params.assignmentId = 'test-assignment';
+    params.hitId = 'test-hit';
+  }
   return params;
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,6 +25,8 @@ export const serverTime = firebase.database.ServerValue.TIMESTAMP;
 // Functions to parse the URL to get workerID, hitID, and assignmentID
 const unescapeURL = (s) => decodeURIComponent(s.replace(/\+/g, '%20'));
 export const getURLParams = () => {
+  const url = window.location.hostname;
+  console.log('curr host:', url);
   const params = {};
   const m = window.location.href.match(/[\\?&]([^=]+)=([^&#]*)/g);
   if (m) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,8 +25,6 @@ export const serverTime = firebase.database.ServerValue.TIMESTAMP;
 // Functions to parse the URL to get workerID, hitID, and assignmentID
 const unescapeURL = (s) => decodeURIComponent(s.replace(/\+/g, '%20'));
 export const getURLParams = () => {
-  const url = window.location.href;
-  console.log('curr host:', url);
   const params = {};
   const m = window.location.href.match(/[\\?&]([^=]+)=([^&#]*)/g);
   if (m) {


### PR DESCRIPTION
Made the following changes:
- changed auth password to workerId (assignmentId will change with each HIT and block repeat users)
- added form submission action and method (POST) to debrief page for communication with mturk
- used params.turkSubmitTo to create url for POST form submission action (switches automatically based on sandbox or real)
- added complete state that is accessed upon submission of debrief. This allows participants to restart upon new trial
- added consent form in same style as app, inserted before instructions (some text needs filling in)